### PR TITLE
Remove debug requires and create executable for testing

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -1,0 +1,9 @@
+#!/usr/bin/env ruby
+
+require 'bundler/setup'
+require 'pokedex'
+require 'pry'
+require 'awesome_print'
+
+Pry.start
+

--- a/lib/pokedex.rb
+++ b/lib/pokedex.rb
@@ -1,7 +1,4 @@
 module Pokedex
-  require 'pry' # only for debug
-  require 'awesome_print' # only for debug
-
   require 'unirest' # for api requests
 
   require 'pokedex/area'


### PR DESCRIPTION
With the actual settings the gem is requiring debugging only gems (`pry` and `awesome_print`) in the main module of the gem `Pokedex`.

Now to open a debugging terminal to test you just have to execute `./bin/console` from the gem's root path.