### PR TITLE
Update code-climate-test-reporter integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,12 @@
 language: ruby
 rvm:
   - 2.2.1
+
 before_install: gem install bundler -v 1.11.2
+
+after_script:
+  - bundle exec codeclimate-test-reporter
+
 addons:
   code_climate:
     repo_token: bb943613033874972517871ea57c9c5e9c2b65120dca6a916d2350c0d5893904

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,5 @@
-require 'codeclimate-test-reporter'
-CodeClimate::TestReporter.start
+require 'simplecov'
+SimpleCov.start
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 
 require 'vcr'


### PR DESCRIPTION
New version of code climate test reporter changes the way that % of coverage is uploaded to codeclimate. This PR updates that.

:eggplant: 